### PR TITLE
Build the exporter directly via the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM golang:latest
+
+COPY . .
+RUN go get -d -v .
+RUN go build .
+
 FROM quay.io/prometheus/busybox:latest
 
 COPY apache_exporter /bin/apache_exporter


### PR DESCRIPTION
This PR simply changes the Dockerfile and allows someone to just run `docker build` to get a working `apache_exporter` binary