### PR TITLE
Build the exporter directly via the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+FROM golang:latest as builder
+
+WORKDIR /go
+COPY . .
+RUN go get -d -v .
+RUN go build -o ./apache_exporter .
+
 FROM quay.io/prometheus/busybox:latest
 
-COPY apache_exporter /bin/apache_exporter
+COPY --from=builder /go/apache_exporter /bin/apache_exporter
 
 ENTRYPOINT ["/bin/apache_exporter"]
 EXPOSE     9117


### PR DESCRIPTION
This PR updates the Dockerfile to allow building the `apache_exporter` binary and the docker image in one single `docker build`