### PR TITLE
Allow setting by environment variables.

### DIFF
--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -300,6 +300,11 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 }
 
 func main() {
+	flag.VisitAll(func(f *flag.Flag) {
+		if value := os.Getenv(strings.ToUpper(f.Name)); value != "" {
+			f.Value.Set(value)
+		}
+	})
 	flag.Parse()
 
 	if *showVersion {

--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -301,7 +301,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 func main() {
 	flag.VisitAll(func(f *flag.Flag) {
-		if value := os.Getenv(strings.ToUpper(f.Name)); value != "" {
+		if value := os.Getenv(strings.ToUpper(strings.Replace(f.Name,".","_", -1))); value != "" {
 			f.Value.Set(value)
 		}
 	})


### PR DESCRIPTION
This is useful when using Basic Authorization.


If you pass as an argument you can see the basic authentication string.

```
# ./apache_exporter -scrape_uri http://exporter:PjYzoJcTmtvP3mYfDh6f@localhost/server-status?aut
-----
$ ps auxfww |grep apache_exporter
root       2257  0.0  0.0 110916  7596 pts/0    Sl+  16:25   0:00  |                   \_ ./apache_exporter -scrape_uri http://exporter:PjYzoJcTmtvP3mYfDh6f@localhost/server-status?auto
```

But passing as an environment variable can hide the basic authentication string.

```
# SCRAPE_URI=http://exporter:PjYzoJcTmtvP3mYfDh6f@localhost/server-status?auto ./apache_exporter
------

$ ps auxfww |grep apache_exporter
root       2496  0.0  0.0 110916  7536 pts/0    Sl+  16:26   0:00  |                   \_ ./apache_exporter
$ ps auxfeww |grep apache_exporter
root       2496  0.0  0.0 110916  7536 pts/0    Sl+  16:26   0:00  |                   \_ ./apache_exporter



```