### PR TITLE
Fix build when the GOPATH envvar is empty or undefined.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 GO    := GO111MODULE=on go
-PROMU := $(GOPATH)/bin/promu
+PROMU := $(shell $(GO) env GOPATH)/bin/promu
 pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)


### PR DESCRIPTION
When the GOPATH envvar is empty or undefined, the PROMU variable expands to just /bin/promu, which is typically incorrect.
This commit replaces the expansion with a proper go env invocation to obtain the correct value of the implicit GOPATH.