### PR TITLE
Add parameters definition as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Help on flags:
       --version           Show application version.
 </pre>
 
+Default values can be changed by environment variables:
+<pre>
+TELEMETRY_ADDRESS
+TELEMETRY_ENDPOINT
+SCRAPE_URI
+HOST_OVERRIDE
+INSECURE (true or false)
+</pre>
+
 Tested on Apache 2.2 and Apache 2.4.
 
  If your server-status page is secured by http auth, add the credentials to the scrape URL following this example:

--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -24,12 +24,20 @@ const (
 	namespace = "apache" // For Prometheus metrics.
 )
 
+func getDefaultFromEnv(environment, defaultValue string) string {
+	value, found := os.LookupEnv(environment)
+	if found {
+		return value
+	}
+	return defaultValue
+}
+
 var (
-	listeningAddress = kingpin.Flag("telemetry.address", "Address on which to expose metrics.").Default(":9117").String()
-	metricsEndpoint  = kingpin.Flag("telemetry.endpoint", "Path under which to expose metrics.").Default("/metrics").String()
-	scrapeURI        = kingpin.Flag("scrape_uri", "URI to apache stub status page.").Default("http://localhost/server-status/?auto").String()
-	hostOverride     = kingpin.Flag("host_override", "Override for HTTP Host header; empty string for no override.").Default("").String()
-	insecure         = kingpin.Flag("insecure", "Ignore server certificate if using https.").Bool()
+	listeningAddress = kingpin.Flag("telemetry.address", "Address on which to expose metrics.").Default(getDefaultFromEnv("TELEMETRY_ADDRESS", ":9117")).String()
+	metricsEndpoint  = kingpin.Flag("telemetry.endpoint", "Path under which to expose metrics.").Default(getDefaultFromEnv("TELEMETRY_ENDPOINT", "/metrics")).String()
+	scrapeURI        = kingpin.Flag("scrape_uri", "URI to apache stub status page.").Default(getDefaultFromEnv("SCRAPE_URI", "http://localhost/server-status/?auto")).String()
+	hostOverride     = kingpin.Flag("host_override", "Override for HTTP Host header; empty string for no override.").Default(getDefaultFromEnv("HOST_OVERRIDE", "")).String()
+	insecure         = kingpin.Flag("insecure", "Ignore server certificate if using https.").Default(getDefaultFromEnv("INSECURE", "false")).Bool()
 	gracefulStop     = make(chan os.Signal)
 )
 


### PR DESCRIPTION
Priority of parameters:
* cmdline flags
* environment variable
* default value

This allows to define apache_exporter parameters as environment
variables.