### PR TITLE
feat: add support for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Help on flags:
       --host_override=""   Override for HTTP Host header; empty string for no
                            override.
       --insecure           Ignore server certificate if using https.
+      --custom_headers     Adds custom headers to the collector.
       --web.config=""      Path to config yaml file that can enable TLS or
                            authentication.
       --log.level=info     Only log messages with the given severity or above.

--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -32,6 +32,7 @@ var (
 	scrapeURI        = kingpin.Flag("scrape_uri", "URI to apache stub status page.").Default("http://localhost/server-status/?auto").String()
 	hostOverride     = kingpin.Flag("host_override", "Override for HTTP Host header; empty string for no override.").Default("").String()
 	insecure         = kingpin.Flag("insecure", "Ignore server certificate if using https.").Bool()
+	customHeaders    = kingpin.Flag("custom_headers", "Adds custom headers to the collector.").StringMap()
 	configFile       = kingpin.Flag("web.config", "Path to config yaml file that can enable TLS or authentication.").Default("").String()
 	gracefulStop     = make(chan os.Signal, 1)
 )
@@ -53,9 +54,10 @@ func main() {
 	signal.Notify(gracefulStop, syscall.SIGQUIT)
 
 	config := &collector.Config{
-		ScrapeURI:    *scrapeURI,
-		HostOverride: *hostOverride,
-		Insecure:     *insecure,
+		ScrapeURI:     *scrapeURI,
+		HostOverride:  *hostOverride,
+		Insecure:      *insecure,
+		CustomHeaders: *customHeaders,
 	}
 
 	webSystemdSocket := false

--- a/apache_exporter_test.go
+++ b/apache_exporter_test.go
@@ -276,6 +276,7 @@ func checkApacheStatus(t *testing.T, status string, metricCount int) {
 		ScrapeURI:    server.URL,
 		HostOverride: "",
 		Insecure:     false,
+		CustomHeaders: map[string]string{"Cookie": "A test cookie"},
 	}
 	e := collector.NewExporter(logger, config)
 	ch := make(chan prometheus.Metric)

--- a/apache_exporter_test.go
+++ b/apache_exporter_test.go
@@ -273,9 +273,9 @@ func checkApacheStatus(t *testing.T, status string, metricCount int) {
 	promlogConfig := &promlog.Config{}
 	logger := promlog.New(promlogConfig)
 	config := &collector.Config{
-		ScrapeURI:    server.URL,
-		HostOverride: "",
-		Insecure:     false,
+		ScrapeURI:     server.URL,
+		HostOverride:  "",
+		Insecure:      false,
 		CustomHeaders: map[string]string{"Cookie": "A test cookie"},
 	}
 	e := collector.NewExporter(logger, config)


### PR DESCRIPTION
- Adds support for adding custom headers to the collector

Example:
```bash
go run apache_exporter.go --custom_headers=Cookie=do_something=1 --custom_headers=Cookie=something_else
```

This is something we use at work and wanted to share :)

#71