### PR TITLE
Fix url syntax for default scrape_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Help on flags:
                                  --help-long and --help-man).
       --telemetry.endpoint="/metrics"
                                  Path under which to expose metrics.
-      --scrape_uri="http://localhost/server-status/?auto"
+      --scrape_uri="http://localhost/server-status?auto"
                                  URI to apache stub status page.
       --host_override=""         Override for HTTP Host header; empty string for
                                  no override.

--- a/apache_exporter.go
+++ b/apache_exporter.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	metricsEndpoint = kingpin.Flag("telemetry.endpoint", "Path under which to expose metrics.").Default("/metrics").String()
-	scrapeURI       = kingpin.Flag("scrape_uri", "URI to apache stub status page.").Default("http://localhost/server-status/?auto").String()
+	scrapeURI       = kingpin.Flag("scrape_uri", "URI to apache stub status page.").Default("http://localhost/server-status?auto").String()
 	hostOverride    = kingpin.Flag("host_override", "Override for HTTP Host header; empty string for no override.").Default("").String()
 	insecure        = kingpin.Flag("insecure", "Ignore server certificate if using https.").Bool()
 	toolkitFlags    = kingpinflag.AddFlags(kingpin.CommandLine, ":9117")


### PR DESCRIPTION
The mod_status docs suggest the correct syntax, a GET param on the `server-status` path. but there are few places that reference `server-status/` (as a directory). Fix up the default for scrape_url and update the README to use the correct path and param.

Note: the README already includes the correctly URI just below, in the usage docs:
https://github.com/Lusitaniae/apache_exporter/blob/634fead49017138d65f802b96c15b30c9af73aca/README.md?plain=1#L46

Docs ref: https://httpd.apache.org/docs/2.4/mod/mod_status.html#machinereadable

Ref: https://github.com/Lusitaniae/apache_exporter/issues/153
(closes?)